### PR TITLE
Add minimal JSON-based scoreboard for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Minimal GitHub Pages scoreboard" />
   <title>Yeti Scoreboard</title>
   <link rel="stylesheet" href="style.css" />
 </head>
@@ -14,6 +15,9 @@
       <input type="number" id="score" placeholder="Score" required />
       <button type="submit">Submit</button>
     </form>
+
+    <!-- Placeholder: future GitHub sync logic will hook into this button -->
+    <button id="syncButton">Sync Scores to GitHub</button>
 
     <section>
       <h2>Leaderboard</h2>

--- a/scores.json
+++ b/scores.json
@@ -1,0 +1,5 @@
+[
+  { "name": "Yeti", "score": 1000 },
+  { "name": "Explorer", "score": 750 },
+  { "name": "Climber", "score": 500 }
+]

--- a/script.js
+++ b/script.js
@@ -1,6 +1,8 @@
 const form = document.getElementById("scoreForm");
 const leaderboard = document.getElementById("leaderboard");
-const scores = JSON.parse(localStorage.getItem("scores") || "[]");
+const syncButton = document.getElementById("syncButton");
+
+let scores = [];
 
 function updateLeaderboard() {
   leaderboard.innerHTML = "";
@@ -13,16 +15,36 @@ function updateLeaderboard() {
     });
 }
 
+async function loadScores() {
+  try {
+    const response = await fetch("scores.json");
+    const remoteScores = await response.json();
+    const localScores = JSON.parse(localStorage.getItem("scores") || "[]");
+    scores = remoteScores.concat(localScores);
+    updateLeaderboard();
+  } catch (err) {
+    console.error("Unable to load scores.json", err);
+  }
+}
+
 form.addEventListener("submit", (e) => {
   e.preventDefault();
   const name = document.getElementById("name").value.trim();
-  const score = parseInt(document.getElementById("score").value);
+  const score = parseInt(document.getElementById("score").value, 10);
   if (name && !isNaN(score)) {
-    scores.push({ name, score });
-    localStorage.setItem("scores", JSON.stringify(scores));
+    const entry = { name, score };
+    scores.push(entry);
+    const localScores = JSON.parse(localStorage.getItem("scores") || "[]");
+    localScores.push(entry);
+    localStorage.setItem("scores", JSON.stringify(localScores));
     updateLeaderboard();
     form.reset();
   }
 });
 
-updateLeaderboard();
+syncButton.addEventListener("click", () => {
+  // TODO: Sync logic will send local scores to GitHub (e.g., via PR or Actions)
+  alert("Sync to GitHub coming soon!");
+});
+
+loadScores();

--- a/style.css
+++ b/style.css
@@ -48,3 +48,17 @@ li {
   padding: 0.75rem;
   border-radius: 4px;
 }
+
+#syncButton {
+  width: 100%;
+  margin-top: 0.5rem;
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 1rem;
+  }
+  h1 {
+    font-size: 1.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- load and render scores from `scores.json` and browser `localStorage`
- dark theme scoreboard with mobile responsive styles and sync placeholder
- add sample score data

## Testing
- `node --check script.js`
- `python -m json.tool scores.json`
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6894eff0d6a483298956a4756af531db