### PR TITLE
Add client-side GitHub sync

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,9 +18,21 @@
       <input type="number" id="score" placeholder="Score" required />
       <button type="submit">Submit</button>
     </form>
+    <section id="config">
+      <h2>GitHub Sync Config</h2>
+      <input type="text" id="owner" placeholder="Owner" />
+      <input type="text" id="repo" placeholder="Repo" />
+      <input type="text" id="branch" placeholder="Branch" value="main" />
+      <input type="password" id="token" placeholder="Token" />
+      <label for="mode">Mode:</label>
+      <select id="mode">
+        <option value="merge">Merge</option>
+        <option value="overwrite">Overwrite</option>
+      </select>
+    </section>
 
-    <!-- Placeholder: future GitHub sync logic will hook into this button -->
     <button id="syncButton">Sync Scores to GitHub</button>
+    <p id="syncStatus"></p>
 
     <section>
       <h2>Leaderboard</h2>

--- a/script.js
+++ b/script.js
@@ -1,8 +1,41 @@
 const form = document.getElementById("scoreForm");
 const leaderboard = document.getElementById("leaderboard");
 const syncButton = document.getElementById("syncButton");
+const syncStatus = document.getElementById("syncStatus");
+
+const ownerInput = document.getElementById("owner");
+const repoInput = document.getElementById("repo");
+const branchInput = document.getElementById("branch");
+const tokenInput = document.getElementById("token");
+const modeSelect = document.getElementById("mode");
 
 let scores = [];
+
+// Load stored config values
+[
+  { el: ownerInput, key: "github_owner" },
+  { el: repoInput, key: "github_repo" },
+  { el: branchInput, key: "github_branch", defaultValue: "main" },
+  { el: tokenInput, key: "github_token" },
+  { el: modeSelect, key: "github_mode", defaultValue: "merge" },
+].forEach(({ el, key, defaultValue }) => {
+  const stored = localStorage.getItem(key) || defaultValue || "";
+  if (stored) {
+    el.value = stored;
+  }
+  el.addEventListener("input", () => {
+    localStorage.setItem(key, el.value);
+  });
+});
+
+// Blur token field when filled for basic obfuscation
+tokenInput.addEventListener("blur", () => {
+  if (tokenInput.value) tokenInput.style.filter = "blur(5px)";
+});
+tokenInput.addEventListener("focus", () => {
+  tokenInput.style.filter = "none";
+});
+if (tokenInput.value) tokenInput.style.filter = "blur(5px)";
 
 function updateLeaderboard() {
   leaderboard.innerHTML = "";
@@ -42,9 +75,68 @@ form.addEventListener("submit", (e) => {
   }
 });
 
-syncButton.addEventListener("click", () => {
-  // TODO: Sync logic will send local scores to GitHub (e.g., via PR or Actions)
-  alert("Sync to GitHub coming soon!");
+syncButton.addEventListener("click", async () => {
+  const owner = ownerInput.value.trim();
+  const repo = repoInput.value.trim();
+  const branch = branchInput.value.trim();
+  const token = tokenInput.value.trim();
+  const mode = modeSelect.value;
+  const localScores = JSON.parse(localStorage.getItem("scores") || "[]");
+
+  if (!owner || !repo || !branch || !token) {
+    syncStatus.textContent = "Missing GitHub configuration.";
+    return;
+  }
+  if (localScores.length === 0) {
+    syncStatus.textContent = "No local scores to sync.";
+    return;
+  }
+
+  syncStatus.textContent = "Uploading...";
+  try {
+    const getUrl = `https://api.github.com/repos/${owner}/${repo}/contents/scores.json?ref=${branch}`;
+    const getRes = await fetch(getUrl, {
+      headers: { Authorization: `token ${token}` },
+    });
+
+    let existing = [];
+    let sha;
+    if (getRes.ok) {
+      const file = await getRes.json();
+      existing = JSON.parse(atob(file.content));
+      sha = file.sha;
+    } else if (getRes.status !== 404) {
+      throw new Error("Failed to fetch scores.json");
+    }
+
+    const updated = mode === "merge" ? existing.concat(localScores) : localScores;
+    const encoded = btoa(JSON.stringify(updated, null, 2));
+
+    const putRes = await fetch(`https://api.github.com/repos/${owner}/${repo}/contents/scores.json`, {
+      method: "PUT",
+      headers: {
+        Authorization: `token ${token}`,
+        "Content-Type": "application/json",
+        Accept: "application/vnd.github+json",
+      },
+      body: JSON.stringify({
+        message: "Update scores.json from Yeti Scoreboard",
+        content: encoded,
+        sha,
+        branch,
+      }),
+    });
+
+    if (!putRes.ok) {
+      const err = await putRes.json();
+      throw new Error(err.message || "Failed to update");
+    }
+
+    syncStatus.textContent = "Upload successful";
+  } catch (err) {
+    console.error(err);
+    syncStatus.textContent = `Failed to update: ${err.message}`;
+  }
 });
 
 loadScores();

--- a/style.css
+++ b/style.css
@@ -54,6 +54,18 @@ li {
   margin-top: 0.5rem;
 }
 
+#config {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+#syncStatus {
+  min-height: 1.2rem;
+  margin-top: 0.5rem;
+}
+
 @media (max-width: 480px) {
   body {
     padding: 1rem;


### PR DESCRIPTION
## Summary
- Add GitHub sync configuration UI and status messaging
- Support merging or overwriting local scores via GitHub API
- Basic styling for config section

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894f397a1e8832993ed72c563025892