### PR TITLE
Add client-side GitHub sync

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,9 +18,8 @@
       <input type="number" id="score" placeholder="Score" required />
       <button type="submit">Submit</button>
     </form>
-
-    <!-- Placeholder: future GitHub sync logic will hook into this button -->
-    <button id="syncButton">Sync Scores to GitHub</button>
+    <button id="syncButton">Sync</button>
+    <p id="syncStatus"></p>
 
     <section>
       <h2>Leaderboard</h2>

--- a/script.js
+++ b/script.js
@@ -1,8 +1,35 @@
 const form = document.getElementById("scoreForm");
 const leaderboard = document.getElementById("leaderboard");
 const syncButton = document.getElementById("syncButton");
+const syncStatus = document.getElementById("syncStatus");
 
 let scores = [];
+
+function getRepoDetails() {
+  const owner = window.location.hostname.split(".")[0];
+  let repo = window.location.pathname.split("/")[1];
+  if (!repo) repo = `${owner}.github.io`;
+  return { owner, repo };
+}
+
+function getToken() {
+  let token = localStorage.getItem("github_token");
+  if (!token) {
+    token = prompt("Enter GitHub token:");
+    if (token) {
+      localStorage.setItem("github_token", token);
+    }
+  }
+  return token;
+}
+
+function dedupe(arr) {
+  const map = new Map();
+  arr.forEach(({ name, score }) => {
+    map.set(`${name}-${score}`, { name, score });
+  });
+  return Array.from(map.values());
+}
 
 function updateLeaderboard() {
   leaderboard.innerHTML = "";
@@ -20,7 +47,7 @@ async function loadScores() {
     const response = await fetch("scores.json");
     const remoteScores = await response.json();
     const localScores = JSON.parse(localStorage.getItem("scores") || "[]");
-    scores = remoteScores.concat(localScores);
+    scores = dedupe(remoteScores.concat(localScores));
     updateLeaderboard();
   } catch (err) {
     console.error("Unable to load scores.json", err);
@@ -42,9 +69,67 @@ form.addEventListener("submit", (e) => {
   }
 });
 
-syncButton.addEventListener("click", () => {
-  // TODO: Sync logic will send local scores to GitHub (e.g., via PR or Actions)
-  alert("Sync to GitHub coming soon!");
+syncButton.addEventListener("click", async () => {
+  const token = getToken();
+  if (!token) {
+    syncStatus.textContent = "Token required.";
+    return;
+  }
+
+  const localScores = JSON.parse(localStorage.getItem("scores") || "[]");
+  if (localScores.length === 0) {
+    syncStatus.textContent = "No local scores to sync.";
+    return;
+  }
+
+  const { owner, repo } = getRepoDetails();
+  const branch = "main";
+
+  syncStatus.textContent = "Uploading...";
+  try {
+    const getUrl = `https://api.github.com/repos/${owner}/${repo}/contents/scores.json?ref=${branch}`;
+    const getRes = await fetch(getUrl, {
+      headers: { Authorization: `token ${token}` },
+    });
+
+    let existing = [];
+    let sha;
+    if (getRes.ok) {
+      const file = await getRes.json();
+      existing = JSON.parse(atob(file.content));
+      sha = file.sha;
+    } else if (getRes.status !== 404) {
+      throw new Error("Failed to fetch scores.json");
+    }
+
+    const updated = dedupe(existing.concat(localScores));
+    const encoded = btoa(JSON.stringify(updated, null, 2));
+
+    const putRes = await fetch(`https://api.github.com/repos/${owner}/${repo}/contents/scores.json`, {
+      method: "PUT",
+      headers: {
+        Authorization: `token ${token}`,
+        "Content-Type": "application/json",
+        Accept: "application/vnd.github+json",
+      },
+      body: JSON.stringify({
+        message: "Update scores.json from Yeti Scoreboard",
+        content: encoded,
+        sha,
+        branch,
+      }),
+    });
+
+    if (!putRes.ok) {
+      const err = await putRes.json();
+      throw new Error(err.message || "Failed to update");
+    }
+
+    syncStatus.textContent = "Upload successful";
+  } catch (err) {
+    console.error(err);
+    syncStatus.textContent = `Failed to update: ${err.message}`;
+  }
 });
 
 loadScores();

--- a/style.css
+++ b/style.css
@@ -54,6 +54,11 @@ li {
   margin-top: 0.5rem;
 }
 
+#syncStatus {
+  min-height: 1.2rem;
+  margin-top: 0.5rem;
+}
+
 @media (max-width: 480px) {
   body {
     padding: 1rem;


### PR DESCRIPTION
## Summary
- Simplify scoreboard to a single **Sync** button that updates `scores.json`
- Prompt for token on first sync and automatically detect repo information
- Deduplicate scores before committing to avoid repeated entries

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894f397a1e8832993ed72c563025892