### PR TITLE
Simplify GitHub sync to single button

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,20 +18,7 @@
       <input type="number" id="score" placeholder="Score" required />
       <button type="submit">Submit</button>
     </form>
-    <section id="config">
-      <h2>GitHub Sync Config</h2>
-      <input type="text" id="owner" placeholder="Owner" />
-      <input type="text" id="repo" placeholder="Repo" />
-      <input type="text" id="branch" placeholder="Branch" value="main" />
-      <input type="password" id="token" placeholder="Token" />
-      <label for="mode">Mode:</label>
-      <select id="mode">
-        <option value="merge">Merge</option>
-        <option value="overwrite">Overwrite</option>
-      </select>
-    </section>
-
-    <button id="syncButton">Sync Scores to GitHub</button>
+    <button id="syncButton">sync</button>
     <p id="syncStatus"></p>
 
     <section>

--- a/script.js
+++ b/script.js
@@ -3,39 +3,14 @@ const leaderboard = document.getElementById("leaderboard");
 const syncButton = document.getElementById("syncButton");
 const syncStatus = document.getElementById("syncStatus");
 
-const ownerInput = document.getElementById("owner");
-const repoInput = document.getElementById("repo");
-const branchInput = document.getElementById("branch");
-const tokenInput = document.getElementById("token");
-const modeSelect = document.getElementById("mode");
+const githubConfig = {
+  owner: "your-owner",
+  repo: "your-repo",
+  branch: "main",
+  token: "your-token",
+};
 
 let scores = [];
-
-// Load stored config values
-[
-  { el: ownerInput, key: "github_owner" },
-  { el: repoInput, key: "github_repo" },
-  { el: branchInput, key: "github_branch", defaultValue: "main" },
-  { el: tokenInput, key: "github_token" },
-  { el: modeSelect, key: "github_mode", defaultValue: "merge" },
-].forEach(({ el, key, defaultValue }) => {
-  const stored = localStorage.getItem(key) || defaultValue || "";
-  if (stored) {
-    el.value = stored;
-  }
-  el.addEventListener("input", () => {
-    localStorage.setItem(key, el.value);
-  });
-});
-
-// Blur token field when filled for basic obfuscation
-tokenInput.addEventListener("blur", () => {
-  if (tokenInput.value) tokenInput.style.filter = "blur(5px)";
-});
-tokenInput.addEventListener("focus", () => {
-  tokenInput.style.filter = "none";
-});
-if (tokenInput.value) tokenInput.style.filter = "blur(5px)";
 
 function updateLeaderboard() {
   leaderboard.innerHTML = "";
@@ -53,7 +28,10 @@ async function loadScores() {
     const response = await fetch("scores.json");
     const remoteScores = await response.json();
     const localScores = JSON.parse(localStorage.getItem("scores") || "[]");
-    scores = remoteScores.concat(localScores);
+    const combined = remoteScores.concat(localScores);
+    scores = Array.from(
+      new Map(combined.map((s) => [`${s.name}|${s.score}`, s])).values()
+    );
     updateLeaderboard();
   } catch (err) {
     console.error("Unable to load scores.json", err);
@@ -76,11 +54,7 @@ form.addEventListener("submit", (e) => {
 });
 
 syncButton.addEventListener("click", async () => {
-  const owner = ownerInput.value.trim();
-  const repo = repoInput.value.trim();
-  const branch = branchInput.value.trim();
-  const token = tokenInput.value.trim();
-  const mode = modeSelect.value;
+  const { owner, repo, branch, token } = githubConfig;
   const localScores = JSON.parse(localStorage.getItem("scores") || "[]");
 
   if (!owner || !repo || !branch || !token) {
@@ -109,23 +83,29 @@ syncButton.addEventListener("click", async () => {
       throw new Error("Failed to fetch scores.json");
     }
 
-    const updated = mode === "merge" ? existing.concat(localScores) : localScores;
-    const encoded = btoa(JSON.stringify(updated, null, 2));
+    const combined = existing.concat(localScores);
+    const unique = Array.from(
+      new Map(combined.map((s) => [`${s.name}|${s.score}`, s])).values()
+    );
+    const encoded = btoa(JSON.stringify(unique, null, 2));
 
-    const putRes = await fetch(`https://api.github.com/repos/${owner}/${repo}/contents/scores.json`, {
-      method: "PUT",
-      headers: {
-        Authorization: `token ${token}`,
-        "Content-Type": "application/json",
-        Accept: "application/vnd.github+json",
-      },
-      body: JSON.stringify({
-        message: "Update scores.json from Yeti Scoreboard",
-        content: encoded,
-        sha,
-        branch,
-      }),
-    });
+    const putRes = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}/contents/scores.json`,
+      {
+        method: "PUT",
+        headers: {
+          Authorization: `token ${token}`,
+          "Content-Type": "application/json",
+          Accept: "application/vnd.github+json",
+        },
+        body: JSON.stringify({
+          message: "Update scores.json from Yeti Scoreboard",
+          content: encoded,
+          sha,
+          branch,
+        }),
+      }
+    );
 
     if (!putRes.ok) {
       const err = await putRes.json();

--- a/style.css
+++ b/style.css
@@ -54,13 +54,6 @@ li {
   margin-top: 0.5rem;
 }
 
-#config {
-  margin-top: 1rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
 #syncStatus {
   min-height: 1.2rem;
   margin-top: 0.5rem;


### PR DESCRIPTION
## Summary
- Remove GitHub configuration UI and replace sync control with a single "sync" button
- Add placeholder GitHub settings in script and deduplicate scores before uploading
- Drop unused config styles for a leaner page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894f965655c83298eea6cc510142c3f