### PR TITLE
Ensure leaderboard syncs instantly

### DIFF
--- a/script.js
+++ b/script.js
@@ -25,7 +25,7 @@ function updateLeaderboard() {
 
 async function loadScores() {
   try {
-    const response = await fetch("scores.json");
+    const response = await fetch("scores.json", { cache: "no-store" });
     const remoteScores = await response.json();
     const localScores = JSON.parse(localStorage.getItem("scores") || "[]");
     const combined = remoteScores.concat(localScores);
@@ -112,6 +112,9 @@ syncButton.addEventListener("click", async () => {
       throw new Error(err.message || "Failed to update");
     }
 
+    scores = unique;
+    localStorage.removeItem("scores");
+    updateLeaderboard();
     syncStatus.textContent = "Upload successful";
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
## Summary
- Fetch scores.json with no-store cache so leaderboard always loads latest scores
- After successful sync, clear local scores and refresh leaderboard for immediate reflection

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894ff293f948329aa6d552c11694726