### PR TITLE
Add Cloudflare Worker configuration and publish docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Yeti Scoreboard
+
+This project includes a Cloudflare Worker for managing scoreboard data.
+
+## Configuration
+
+Set up environment variables in `wrangler.toml`:
+
+- `ALLOWED_ORIGIN`
+- `ADMIN_SECRET`
+- `GITHUB_OWNER`
+- `GITHUB_REPO`
+- `GITHUB_BRANCH`
+
+`GITHUB_TOKEN` should be stored as a secret:
+
+```sh
+npx wrangler secret put GITHUB_TOKEN
+```
+
+## Deploying
+
+Publish the Worker to Cloudflare:
+
+```sh
+npx wrangler publish
+```

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,11 @@
+name = "yeti-scoreboard"
+main = "worker.js"
+compatibility_date = "2024-08-07"
+
+[vars]
+ALLOWED_ORIGIN = ""
+ADMIN_SECRET = ""
+GITHUB_OWNER = ""
+GITHUB_REPO = ""
+GITHUB_BRANCH = ""
+# Note: GITHUB_TOKEN is set via `wrangler secret put GITHUB_TOKEN`


### PR DESCRIPTION
## Summary
- configure Cloudflare Worker via `wrangler.toml` pointing to `worker.js`
- document environment variables and deployment steps in `README`

## Testing
- `npx wrangler publish --dry-run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/wrangler)*

------
https://chatgpt.com/codex/tasks/task_e_689539e88a908329b5b621ec947a42d0