### PR TITLE
Improve error logging around GitHub updates

### DIFF
--- a/script.js
+++ b/script.js
@@ -64,15 +64,20 @@ async function syncScores() {
       },
       body: JSON.stringify(localScores),
     });
-    const data = await res.json().catch(() => ({}));
+    const text = await res.text();
+    let data = {};
+    try {
+      data = JSON.parse(text);
+    } catch {}
     if (!res.ok || !data.success) {
-      throw new Error(data.error || `Upload failed with status ${res.status}`);
+      console.error("Upload failed", res.status, text);
+      throw new Error(data.error || `Upload failed: ${res.status} ${text}`);
     }
     localStorage.removeItem("scores");
     await loadScores();
     syncStatus.textContent = "Upload successful";
   } catch (err) {
-    console.error(err);
+    console.error("Sync failed", err);
     syncStatus.textContent = `Failed to update: ${err.message}`;
   }
 }

--- a/worker.js
+++ b/worker.js
@@ -65,10 +65,17 @@ export default {
         sha = file.sha;
       } else {
         const errText = await getRes.text();
-        return new Response(JSON.stringify({ success: false, error: `Failed to fetch scores.json: ${errText}` }), {
-          status: getRes.status,
-          headers: { 'Content-Type': 'application/json', ...corsHeaders },
-        });
+        console.error('Failed to fetch scores.json', getRes.status, errText);
+        return new Response(
+          JSON.stringify({
+            success: false,
+            error: `GitHub fetch failed: ${getRes.status} ${errText}`,
+          }),
+          {
+            status: getRes.status,
+            headers: { 'Content-Type': 'application/json', ...corsHeaders },
+          }
+        );
       }
 
       const encoded = btoa(JSON.stringify(scores, null, 2));
@@ -86,21 +93,32 @@ export default {
       });
 
       if (!putRes.ok) {
-        const err = await putRes.json().catch(() => ({}));
-        return new Response(JSON.stringify({ success: false, error: err.message || 'Failed to update scores.json' }), {
-          status: putRes.status,
-          headers: { 'Content-Type': 'application/json', ...corsHeaders },
-        });
+        const errText = await putRes.text();
+        console.error('Failed to update scores.json', putRes.status, errText);
+        return new Response(
+          JSON.stringify({
+            success: false,
+            error: `GitHub update failed: ${putRes.status} ${errText}`,
+          }),
+          {
+            status: putRes.status,
+            headers: { 'Content-Type': 'application/json', ...corsHeaders },
+          }
+        );
       }
 
       return new Response(JSON.stringify({ success: true }), {
         headers: { 'Content-Type': 'application/json', ...corsHeaders },
       });
     } catch (err) {
-      return new Response(JSON.stringify({ success: false, error: err.message }), {
-        status: 500,
-        headers: { 'Content-Type': 'application/json', ...corsHeaders },
-      });
+      console.error('Unexpected error while updating scores', err);
+      return new Response(
+        JSON.stringify({ success: false, error: err.message }),
+        {
+          status: 500,
+          headers: { 'Content-Type': 'application/json', ...corsHeaders },
+        }
+      );
     }
   },
 };


### PR DESCRIPTION
## Summary
- log status and response text when GitHub fetch or update fails in worker
- surface GitHub response details on client upload failures

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68953eab1680832983f5071b9f16c46c