### PR TITLE
Enhance scoreboard with KV sync and playful UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,8 +31,9 @@
     <button id="syncBtn">sync</button>
 
     <section>
-      <h2>Leaderboard</h2>
+      <h2>Leaderboard <small id="lastUpdated"></small></h2>
       <ul id="leaderboard"></ul>
+      <button id="toggleBtn" class="hidden">Show all</button>
     </section>
   </main>
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -4,11 +4,18 @@
 const CONFIG = {
   WORKER_URL: "https://yeti-kv-sync.anonymity.workers.dev",
   ADMIN_KEY_STORAGE: "yeti_admin_key",
+  TOP_N: 10,
+  COOLDOWN_MS: 4000,
 };
 
 // DOM elements
 const form = document.getElementById("scoreForm");
+const nameInput = document.getElementById("name");
+const scoreInput = document.getElementById("score");
+const submitBtn = form.querySelector("button[type='submit']");
 const leaderboard = document.getElementById("leaderboard");
+const toggleBtn = document.getElementById("toggleBtn");
+const lastUpdatedEl = document.getElementById("lastUpdated");
 const syncBtn = document.getElementById("syncBtn");
 const banner = document.getElementById("banner");
 const adminPanel = document.getElementById("adminPanel");
@@ -16,87 +23,131 @@ const adminKeyInput = document.getElementById("adminKey");
 const saveAdminKeyBtn = document.getElementById("saveAdminKey");
 
 let scores = [];
+let showAll = false;
+let cooldownTimer;
 
-/**
- * Display a warning banner.
- */
 function showBanner(message) {
   if (!banner) return;
   banner.textContent = message;
   banner.classList.remove("hidden");
 }
+function hideBanner() {
+  if (!banner) return;
+  banner.classList.add("hidden");
+}
 
-/**
- * Validate initial configuration and admin key.
- */
 function validateSetup() {
-  const urlPattern = /^https:\/\/[\w.-]+\.workers\.dev\/?$/;
-  if (!urlPattern.test(CONFIG.WORKER_URL)) {
+  const valid =
+    CONFIG.WORKER_URL.startsWith("https://") &&
+    CONFIG.WORKER_URL.endsWith(".workers.dev");
+  if (!valid) {
     console.error("Invalid Worker URL", CONFIG.WORKER_URL);
-    showBanner(`Invalid Worker URL: ${CONFIG.WORKER_URL}`);
-  }
-  if (!localStorage.getItem(CONFIG.ADMIN_KEY_STORAGE)) {
-    console.log(
-      "Admin key not set. Press Ctrl+Shift+K to open Admin panel and save key."
+    showBanner(
+      `Worker unreachable. Check CONFIG.WORKER_URL (${CONFIG.WORKER_URL}) and Cloudflare deployment.`
     );
   }
 }
 
-/**
- * Check if the Worker URL is reachable.
- */
 async function healthCheck() {
   try {
     await fetch(CONFIG.WORKER_URL, { method: "GET" });
-  } catch (err) {
+    hideBanner();
+  } catch (_) {
     showBanner(
-      `Worker URL unreachable. Check CONFIG.WORKER_URL (${CONFIG.WORKER_URL}) and Cloudflare deployment.`
+      `Worker unreachable. Check CONFIG.WORKER_URL (${CONFIG.WORKER_URL}) and Cloudflare deployment.`
     );
   }
 }
 
-/**
- * Update leaderboard with medal icons.
- */
-function updateLeaderboard() {
-  leaderboard.innerHTML = "";
-  scores
-    .sort((a, b) => b.score - a.score)
-    .forEach(({ name, score }, index) => {
-      const li = document.createElement("li");
-      let medal = "";
-      if (index === 0) medal = "🥇 ";
-      else if (index === 1) medal = "🥈 ";
-      else if (index === 2) medal = "🥉 ";
-      li.textContent = `${medal}${name}: ${score}`;
-      leaderboard.appendChild(li);
-    });
+function getInitials(name) {
+  return name
+    .split(/\s+/)
+    .map((n) => n[0].toUpperCase())
+    .slice(0, 2)
+    .join("");
+}
+function colorFromName(name) {
+  let h = 0;
+  for (let i = 0; i < name.length; i++) {
+    h = name.charCodeAt(i) + ((h << 5) - h);
+  }
+  return `hsl(${h % 360},70%,70%)`;
 }
 
-/**
- * Load scores from Cloudflare KV.
- */
+function updateLeaderboard(data = scores) {
+  leaderboard.innerHTML = "";
+  const me = localStorage.getItem("playerName") || "";
+  const sorted = [...data].sort((a, b) => b.score - a.score);
+  const limit = showAll ? sorted.length : CONFIG.TOP_N;
+
+  sorted.slice(0, limit).forEach((entry, index) => {
+    const li = document.createElement("li");
+    li.classList.add("fade-in");
+    if (entry.name === me) li.classList.add("me");
+
+    const rank =
+      index === 0 ? "🥇" : index === 1 ? "🥈" : index === 2 ? "🥉" : `#${
+        index + 1
+      }`;
+
+    const rankSpan = document.createElement("span");
+    rankSpan.textContent = rank;
+
+    const avatar = document.createElement("span");
+    avatar.className = "avatar";
+    avatar.style.backgroundColor = colorFromName(entry.name);
+    avatar.textContent = getInitials(entry.name);
+
+    const nameSpan = document.createElement("span");
+    nameSpan.textContent = entry.name;
+
+    const scoreSpan = document.createElement("span");
+    scoreSpan.className = "score";
+    scoreSpan.textContent = entry.score;
+
+    li.append(rankSpan, avatar, nameSpan, scoreSpan);
+
+    if (entry.delta && entry.delta > 0) {
+      const deltaSpan = document.createElement("span");
+      deltaSpan.className = "delta";
+      deltaSpan.textContent = `+${entry.delta}`;
+      li.appendChild(deltaSpan);
+      delete entry.delta;
+    }
+
+    leaderboard.appendChild(li);
+  });
+
+  if (toggleBtn) {
+    toggleBtn.textContent = showAll ? "Collapse" : "Show all";
+    toggleBtn.classList.toggle("hidden", sorted.length <= CONFIG.TOP_N);
+  }
+}
+
 async function loadScores() {
   try {
-    const res = await fetch(CONFIG.WORKER_URL, { method: "GET" });
+    const res = await fetch(CONFIG.WORKER_URL);
     const data = await res.json();
     scores = Array.isArray(data) ? data : [];
     localStorage.setItem("scores", JSON.stringify(scores));
+    if (lastUpdatedEl) {
+      const t = new Date();
+      lastUpdatedEl.textContent = `Last updated: ${t.toLocaleTimeString([], {
+        hour: "2-digit",
+        minute: "2-digit",
+      })}`;
+    }
+    updateLeaderboard(scores);
   } catch (err) {
     console.error("Unable to load scores from KV", err);
-    if (err instanceof TypeError) {
-      showBanner(
-        "If testing from a different origin, temporarily set ALLOWED_ORIGIN='*' in Worker variables or test from the live Pages URL."
-      );
+    const cached = localStorage.getItem("scores");
+    if (cached) {
+      scores = JSON.parse(cached);
+      updateLeaderboard(scores);
     }
-    scores = JSON.parse(localStorage.getItem("scores") || "[]");
   }
-  updateLeaderboard();
 }
 
-/**
- * Sync local scores to KV (admin only).
- */
 async function syncScores() {
   const adminKey = localStorage.getItem(CONFIG.ADMIN_KEY_STORAGE) || "";
   const localScores = JSON.parse(localStorage.getItem("scores") || "[]");
@@ -113,39 +164,73 @@ async function syncScores() {
     if (res.ok) {
       alert(`✅ Synced to KV! Total: ${localScores.length}`);
     } else {
+      console.error("Sync failed", res.status, text);
       throw new Error(text || res.statusText);
     }
   } catch (err) {
-    if (err instanceof TypeError) {
-      showBanner(
-        "If testing from a different origin, temporarily set ALLOWED_ORIGIN='*' in Worker variables or test from the live Pages URL."
-      );
-    }
     alert(`❌ Sync failed: ${err.message}`);
   }
 }
 
-// Add score via form
 form.addEventListener("submit", (e) => {
   e.preventDefault();
-  const name = document.getElementById("name").value.trim();
-  const score = parseInt(document.getElementById("score").value, 10);
-  if (name && !isNaN(score)) {
-    scores.push({ name, score });
-    localStorage.setItem("scores", JSON.stringify(scores));
-    updateLeaderboard();
-    form.reset();
+  const name = nameInput.value.trim();
+  const score = parseInt(scoreInput.value, 10);
+  if (!name || isNaN(score)) return;
+
+  const existing = scores.find((s) => s.name === name);
+  if (existing) {
+    if (score > existing.score) {
+      existing.delta = score - existing.score;
+      existing.score = score;
+    } else {
+      existing.delta = 0;
+    }
+  } else {
+    scores.push({ name, score, delta: 0 });
   }
+
+  localStorage.setItem("scores", JSON.stringify(scores));
+  localStorage.setItem("playerName", name);
+  updateLeaderboard(scores);
+
+  form.reset();
+  nameInput.value = name;
+
+  let remaining = CONFIG.COOLDOWN_MS / 1000;
+  submitBtn.disabled = true;
+  submitBtn.textContent = `Wait (${remaining})`;
+  cooldownTimer = setInterval(() => {
+    remaining--;
+    if (remaining > 0) {
+      submitBtn.textContent = `Wait (${remaining})`;
+    } else {
+      clearInterval(cooldownTimer);
+      submitBtn.disabled = false;
+      submitBtn.textContent = "Submit";
+    }
+  }, 1000);
 });
 
-// Reveal admin panel with Ctrl+Shift+K
+toggleBtn.addEventListener("click", () => {
+  showAll = !showAll;
+  updateLeaderboard();
+});
+
 document.addEventListener("keydown", (e) => {
   if (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === "k") {
     adminPanel.classList.toggle("hidden");
+    if (!adminPanel.classList.contains("hidden")) {
+      adminKeyInput.value =
+        localStorage.getItem(CONFIG.ADMIN_KEY_STORAGE) || "";
+      adminKeyInput.focus();
+    }
+  }
+  if (e.ctrlKey && e.key === "Enter") {
+    syncScores();
   }
 });
 
-// Save admin key
 saveAdminKeyBtn.addEventListener("click", () => {
   const value = adminKeyInput.value.trim();
   localStorage.setItem(CONFIG.ADMIN_KEY_STORAGE, value);
@@ -153,10 +238,10 @@ saveAdminKeyBtn.addEventListener("click", () => {
   adminPanel.classList.add("hidden");
 });
 
-// Wire sync button
 syncBtn.addEventListener("click", syncScores);
 
-// Startup sequence
+nameInput.value = localStorage.getItem("playerName") || "";
+
 validateSetup();
 healthCheck();
 loadScores();

--- a/style.css
+++ b/style.css
@@ -17,7 +17,11 @@ body {
   color: #fff;
   padding: 0.5rem;
   text-align: center;
-  margin-bottom: 1rem;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 10;
 }
 
 #adminPanel {
@@ -38,11 +42,15 @@ body {
 main {
   max-width: 600px;
   width: 100%;
+  margin-top: 3rem;
 }
 
-h1 {
+h1,
+h2 {
   text-align: center;
-  color: #55e6a5;
+  background: linear-gradient(90deg, #55e6a5, #a3f7d3);
+  -webkit-background-clip: text;
+  color: transparent;
 }
 
 form {
@@ -51,7 +59,8 @@ form {
   gap: 0.5rem;
 }
 
-input, button {
+input,
+button {
   padding: 0.75rem;
   font-size: 1rem;
   border: none;
@@ -64,6 +73,12 @@ button {
   cursor: pointer;
 }
 
+input:focus,
+button:focus {
+  outline: 2px solid #55e6a5;
+  outline-offset: 2px;
+}
+
 ul {
   list-style: none;
   padding: 0;
@@ -73,17 +88,61 @@ li {
   background: #222;
   margin-bottom: 0.5rem;
   padding: 0.75rem;
-  border-radius: 4px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  transition: box-shadow 0.2s;
 }
 
-#syncButton {
+li:hover {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+}
+
+.avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  color: #111;
+}
+
+.delta {
+  color: #55e6a5;
+  font-size: 0.8rem;
+  margin-left: 0.25rem;
+}
+
+.delta::before {
+  content: "\2191";
+  margin-right: 2px;
+}
+
+.me {
+  box-shadow: 0 0 8px rgba(85, 230, 165, 0.7);
+}
+
+.fade-in {
+  animation: fadeSlide 0.3s ease-in;
+}
+
+@keyframes fadeSlide {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+#toggleBtn {
+  margin-top: 0.5rem;
   width: 100%;
-  margin-top: 0.5rem;
-}
-
-#syncStatus {
-  min-height: 1.2rem;
-  margin-top: 0.5rem;
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
- centralize configuration and add worker health checks
- load and sync scores from Cloudflare KV with admin key management
- revamp leaderboard UI with avatars, medals, deltas, and top-N toggle

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_6895516dcb248329b2efdeaee020e9cb