### PR TITLE
Improve KV sync and admin controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,8 +9,8 @@
 </head>
 <body>
   <div id="banner" class="banner hidden"></div>
-  <div id="adminPanel" class="hidden">
-    <input type="password" id="adminKey" placeholder="Admin API Key" />
+  <div id="adminPanel" style="display:none; gap:.5rem; margin:.5rem 0;">
+    <input id="adminKey" type="password" placeholder="Admin API key" />
     <button id="saveAdminKey">Save</button>
   </div>
   <main>
@@ -22,13 +22,19 @@
       height="412"
       allowfullscreen
     ></iframe>
-    <h1>🏔️ Yeti Scoreboard</h1>
+    <h1 class="logo">
+      <svg viewBox="0 0 24 24" width="32" height="32" aria-hidden="true">
+        <path class="accent" d="M3 20h18L12 4 3 20z"></path>
+        <path class="snow" d="M12 8l4 8H8l4-8z"></path>
+      </svg>
+      Yeti Scoreboard
+    </h1>
     <form id="scoreForm">
       <input type="text" id="name" placeholder="Name" required />
       <input type="number" id="score" placeholder="Score" required />
       <button type="submit">Submit</button>
     </form>
-    <button id="syncBtn">sync</button>
+    <button id="syncBtn">Sync</button>
 
     <section>
       <h2>Leaderboard <small id="lastUpdated"></small></h2>

--- a/style.css
+++ b/style.css
@@ -24,21 +24,6 @@ body {
   z-index: 10;
 }
 
-#adminPanel {
-  position: fixed;
-  top: 1rem;
-  right: 1rem;
-  background: #222;
-  padding: 1rem;
-  border: 1px solid #55e6a5;
-  border-radius: 4px;
-}
-
-#adminPanel input {
-  margin-bottom: 0.5rem;
-  width: 200px;
-}
-
 main {
   max-width: 600px;
   width: 100%;
@@ -143,6 +128,29 @@ li:hover {
 #toggleBtn {
   margin-top: 0.5rem;
   width: 100%;
+}
+
+#syncBtn {
+  display: block;
+  width: 100%;
+  margin-top: 10px;
+  padding: 0.75rem;
+  border-radius: 6px;
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.logo svg .accent {
+  fill: #55e6a5;
+}
+
+.logo svg .snow {
+  fill: #fff;
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
- Add central CONFIG and validation for Cloudflare Worker URL
- Load and sync scores with localStorage and admin key, plus admin panel shortcut
- Style full-width Sync button and restore two-tone Yeti icon

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68955582984c832987732a59b40d4d65