### PR TITLE
Hardcode admin key for Cloudflare sync

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,10 +9,6 @@
 </head>
 <body>
   <div id="banner" class="banner hidden"></div>
-  <div id="adminPanel" style="display:none; gap:.5rem; margin:.5rem 0;">
-    <input id="adminKey" type="password" placeholder="Admin API key" />
-    <button id="saveAdminKey">Save</button>
-  </div>
   <main>
     <iframe
       src="https://www.gameflare.com/embed/yeti-sports-bloody/"


### PR DESCRIPTION
## Summary
- remove admin panel and localStorage logic for API key
- hardcode admin key in config and send headers on all fetches
- log warning about insecure hardcoded key

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895cff3f2188329930e09c5c8cf93fd