### PR TITLE
refactor: simplify layout and remove csv export

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,6 @@
         <button type="submit" class="primary" id="submitBtn">Submit</button>
       </form>
       <button id="syncBtn" class="secondary">Sync</button>
-      <button id="downloadBtn" class="secondary">Download CSV</button>
       <div id="status" aria-live="polite"></div>
     </div>
 

--- a/script.js
+++ b/script.js
@@ -19,7 +19,6 @@ const leaderboard = document.getElementById("leaderboard");
 const toggleBtn = document.getElementById("toggleBtn");
 const lastUpdatedEl = document.getElementById("lastUpdated");
 const syncBtn = document.getElementById("syncBtn");
-const downloadBtn = document.getElementById("downloadBtn");
 const banner = document.getElementById("banner");
 const statusEl = document.getElementById("status");
 
@@ -344,28 +343,13 @@ document.addEventListener("keydown", (e) => {
   }
 });
 
-syncBtn.addEventListener("click", syncScores);
-downloadBtn.addEventListener("click", downloadCSV);
+  syncBtn.addEventListener("click", syncScores);
 
-function downloadCSV() {
-  const rows = ["name,score"]; // header
-  scores
-    .slice()
-    .sort((a, b) => b.score - a.score)
-    .forEach((s) => rows.push(`${s.name},${fmt(s.score)}`));
-  const blob = new Blob([rows.join("\n")], { type: "text/csv" });
-  const a = document.createElement("a");
-  a.href = URL.createObjectURL(blob);
-  a.download = "scores.csv";
-  a.click();
-  URL.revokeObjectURL(a.href);
-}
+  nameInput.value = localStorage.getItem("playerName") || "";
 
-nameInput.value = localStorage.getItem("playerName") || "";
-
-validateSetup();
-loadScores();
-setInterval(loadScores, 25000);
+  validateSetup();
+  loadScores();
+  setInterval(loadScores, 25000);
 
 function checkLeaderChange(data) {
   const leader = data[0] ? data[0].name : undefined;

--- a/style.css
+++ b/style.css
@@ -5,7 +5,8 @@ body {
   margin: 0;
   padding: 0 1rem 2rem;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
 }
 
 .hidden {
@@ -46,7 +47,7 @@ header.header {
 }
 
 main {
-  max-width: 640px;
+  max-width: 720px;
   width: 100%;
 }
 
@@ -261,17 +262,9 @@ li.score-updated {
   width: 100%;
 }
 
-#syncBtn,
-#downloadBtn {
-  width: 100%;
-}
-
 #syncBtn {
+  width: 100%;
   margin-top: 12px;
-}
-
-#downloadBtn {
-  margin-top: 10px;
 }
 
 button.loading::after {


### PR DESCRIPTION
## Summary
- center main content and widen game viewport
- remove CSV download button and related script

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898b1bd9844832991ad0eeab08a874b