### PR TITLE
Animate score delta without layout shifts

### DIFF
--- a/script.js
+++ b/script.js
@@ -136,6 +136,10 @@ function updateLeaderboard(data = scores) {
         index + 1
       }`;
 
+    // icons column
+    const icons = document.createElement("div");
+    icons.className = "icons";
+
     const rankSpan = document.createElement("span");
     rankSpan.textContent = rank;
 
@@ -144,7 +148,14 @@ function updateLeaderboard(data = scores) {
     avatar.style.backgroundColor = colorFromName(entry.name);
     avatar.textContent = getInitials(entry.name);
 
+    icons.append(rankSpan, avatar);
+
+    // name + delta
+    const nameWrap = document.createElement("div");
+    nameWrap.className = "namewrap";
+
     const nameSpan = document.createElement("span");
+    nameSpan.className = "name";
     nameSpan.textContent = entry.name;
     if (ties.has(entry.name)) {
       const tie = document.createElement("span");
@@ -153,24 +164,47 @@ function updateLeaderboard(data = scores) {
       nameSpan.appendChild(tie);
     }
 
-    const scoreSpan = document.createElement("span");
-    scoreSpan.className = "score";
-    scoreSpan.textContent = fmt(entry.score);
+    const deltaSlot = document.createElement("span");
+    deltaSlot.className = "delta-slot";
+    const deltaFx = document.createElement("span");
+    deltaFx.className = "delta-fx";
+    deltaFx.setAttribute("aria-hidden", "true");
+    deltaSlot.appendChild(deltaFx);
 
-    li.append(rankSpan, avatar, nameSpan, scoreSpan);
+    nameWrap.append(nameSpan, deltaSlot);
+
+    // score column
+    const scoreDiv = document.createElement("div");
+    scoreDiv.className = "score";
+
+    const scoreNum = document.createElement("span");
+    scoreNum.className = "score-num";
+    scoreNum.textContent = fmt(entry.score);
+    scoreDiv.appendChild(scoreNum);
 
     if (index === 0) {
       const trophy = document.createElement("span");
       trophy.className = "trophy";
       trophy.textContent = "🏆";
-      li.appendChild(trophy);
+      scoreDiv.appendChild(trophy);
     }
 
+    li.append(icons, nameWrap, scoreDiv);
+
     if (entry.delta && entry.delta > 0) {
-      const deltaSpan = document.createElement("span");
-      deltaSpan.className = "delta";
-      deltaSpan.textContent = `+${fmt(entry.delta)}`;
-      li.appendChild(deltaSpan);
+      deltaFx.textContent = `+${fmt(entry.delta)}`;
+      deltaFx.classList.remove("show");
+      setTimeout(() => {
+        deltaFx.classList.add("show");
+      }, 500);
+      deltaFx.addEventListener(
+        "animationend",
+        () => {
+          deltaFx.classList.remove("show");
+          deltaFx.textContent = "";
+        },
+        { once: true }
+      );
       delete entry.delta;
     }
 

--- a/style.css
+++ b/style.css
@@ -152,9 +152,10 @@ li {
   margin-bottom: 0.5rem;
   padding: 0 0.75rem;
   border-radius: 8px;
-  display: flex;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
-  gap: 0.75rem;
+  gap: 12px;
   height: 56px;
   transition: box-shadow 0.2s, transform 0.2s;
 }
@@ -183,9 +184,26 @@ li.first {
   color: #111;
 }
 
+.icons {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 72px;
+}
+
+.namewrap {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .score {
-  margin-left: auto;
+  display: flex;
+  align-items: center;
   text-align: right;
+}
+
+.score-num {
   font-variant-numeric: tabular-nums;
   font-family: 'Courier New', monospace;
 }
@@ -202,16 +220,28 @@ li.first {
   margin-left: 4px;
 }
 
-.delta {
-  color: #55e6a5;
-  font-size: 0.8rem;
-  margin-left: 0.25rem;
-  animation: floatUp 0.8s ease-out forwards;
+
+.delta-slot {
+  position: relative;
+  display: inline-block;
+  width: 4.5ch;
+  height: 1.2em;
+  overflow: visible;
 }
 
-.delta::before {
-  content: "\2191";
-  margin-right: 2px;
+.delta-fx {
+  position: absolute;
+  left: 0;
+  top: 0;
+  opacity: 0;
+  pointer-events: none;
+  font-weight: 700;
+  transform: translateY(0) scale(0.95);
+  transition: none;
+}
+
+.delta-fx.show {
+  animation: deltaPop 1.2s ease-out forwards;
 }
 
 .me {
@@ -235,14 +265,18 @@ li.score-updated {
   animation: scoreFlash 1s ease-out;
 }
 
-@keyframes floatUp {
-  from {
-    opacity: 1;
-    transform: translateY(0);
-  }
-  to {
+@keyframes deltaPop {
+  0% {
     opacity: 0;
-    transform: translateY(-10px);
+    transform: translateY(6px) scale(0.95);
+  }
+  15% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-16px) scale(1);
   }
 }
 


### PR DESCRIPTION
## Summary
- Reserve a fixed delta slot in each leaderboard row and convert rows to CSS grid for stable alignment
- Add delayed `deltaPop` animation and keyframes for floating score deltas
- Rework leaderboard rendering to populate `.delta-fx` elements and animate deltas without affecting layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898b69387d88329ac2893d31a2ecc68