### PR TITLE
Adjust refresh interval and score alignment

### DIFF
--- a/script.js
+++ b/script.js
@@ -6,6 +6,7 @@ const CONFIG = {
   ADMIN_KEY: "yeti_38ksL9Q2mA!",
   TOP_N: 10,
   COOLDOWN_MS: 4000,
+  REFRESH_MS: 60000,
 };
 
 console.log("⚠ Using hardcoded admin key — scoreboard is not secure.");
@@ -383,7 +384,7 @@ document.addEventListener("keydown", (e) => {
 
   validateSetup();
   loadScores();
-  setInterval(loadScores, 25000);
+  setInterval(loadScores, CONFIG.REFRESH_MS);
 
 function checkLeaderChange(data) {
   const leader = data[0] ? data[0].name : undefined;

--- a/style.css
+++ b/style.css
@@ -200,7 +200,8 @@ li.first {
 .score {
   display: flex;
   align-items: center;
-  text-align: right;
+  justify-content: flex-start;
+  text-align: left;
 }
 
 .score-num {


### PR DESCRIPTION
## Summary
- refresh leaderboard every 60 seconds via configurable REFRESH_MS
- left-align score column to prevent misaligned digits and trophy

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898bc42653c83298d771d8db7d38adc