### PR TITLE
Combine submit and sync actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,6 @@
         />
         <button type="submit" class="primary" id="submitBtn">Submit</button>
       </form>
-      <button id="syncBtn" class="secondary">Sync</button>
       <div id="status" aria-live="polite"></div>
     </div>
 

--- a/style.css
+++ b/style.css
@@ -297,11 +297,6 @@ li.score-updated {
   width: 100%;
 }
 
-#syncBtn {
-  width: 100%;
-  margin-top: 12px;
-}
-
 button.loading::after {
   content: "";
   width: 16px;


### PR DESCRIPTION
## Summary
- Remove standalone sync button from UI and stylesheet
- Refactor syncScores to accept optional button and return success
- Invoke syncScores in submit handler for one-click submit+sync

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a1cecd56083299036c101a66b9e7a